### PR TITLE
Fix/digest and minor things

### DIFF
--- a/src/module/device.ts
+++ b/src/module/device.ts
@@ -174,7 +174,7 @@ export class OnvifDevice extends EventEmitter{
         }
 
         if (!this.services.ptz) {
-            return Promise.reject(new Error('The device does not support snaphost or you have not authorized by the device'));
+            return Promise.reject(new Error('The device does not support PTZ'));
         }
 
         const x = params.speed.x || 0;
@@ -199,7 +199,7 @@ export class OnvifDevice extends EventEmitter{
         }
 
         if (!this.services.ptz) {
-            return Promise.reject(new Error('The device does not support snaphost or you have not authorized by the device'));
+            return Promise.reject(new Error('The device does not support PTZ'));
         }
 
         this.ptzMoving = false;
@@ -294,7 +294,7 @@ export class OnvifDevice extends EventEmitter{
             this.lastResponse = res;
             const rawProfiles = res.data?.GetProfilesResponse?.Profiles as any[] | any;
             if (!rawProfiles) {
-                throw new Error('Failed to initialize the device: The targeted device does not any media profiles.');
+                throw new Error('Failed to initialize the device: The targeted device does not have any media profiles.');
             }
             const profiles: any[] = [].concat(rawProfiles);
             profiles.forEach((p) => {

--- a/src/module/device.ts
+++ b/src/module/device.ts
@@ -449,7 +449,7 @@ export class OnvifDevice extends EventEmitter{
             }
             try {
                 const params = { ProfileToken: profile.token};
-                const result = await this.services.media.GetSnapshotUri(params);
+                const result = await this.services.media.getSnapshotUri(params);
                 this.lastResponse = result;
                 let snapshotUri = result.data.GetSnapshotUriResponse.MediaUri.Uri;
                 snapshotUri = this.getSnapshotUri(snapshotUri);

--- a/src/module/http-auth.ts
+++ b/src/module/http-auth.ts
@@ -54,7 +54,7 @@ export class OnvifHttpAuth {
         h.split(/,\s*/).forEach((s) => {
             const pair = s.split('=');
             const k = pair[0] as 'algorithm' | 'nonce' | 'Digest realm' | 'qop';
-            let v = pair[1];
+            let v = pair.slice(1).join('=');
             if(!k || !v) {
                 return;
             }

--- a/src/module/service-device.ts
+++ b/src/module/service-device.ts
@@ -241,9 +241,9 @@ export class OnvifServiceDevice extends OnvifServiceBase{
         const soapBody = '<tds:GetUsers/>';
         const soap = this.createRequestSoap(soapBody);
         return requestCommand(this.oxaddr, 'GetUsers', soap).then((result) => {
-            const d = result.data?.GetUserResponse?.User;
+            const d = result.data?.GetUsersResponse?.User;
             if (d && !Array.isArray(d)) {
-                result.data.GetUserResponse.User = [d];
+                result.data.GetUsersResponse.User = [d];
             }
             return result;
         });
@@ -266,7 +266,7 @@ export class OnvifServiceDevice extends OnvifServiceBase{
     deleteUser(params: DeleteUserParams): Promise<Result> {
         let soapBody = '<tds:DeleteUsers>';
         params.User.forEach((u) => {
-			soapBody += `<tt:Username>${u.Username}</tt:Username>`;
+			soapBody += `<tds:Username>${u.Username}</tds:Username>`;
         });
         soapBody += '</tds:DeleteUsers>';
         const soap = this.createRequestSoap(soapBody);
@@ -274,21 +274,19 @@ export class OnvifServiceDevice extends OnvifServiceBase{
     }
 
     setUser(params: SetUserParams): Promise<Result> {
-        let soapBody = '<tds:SetUsers>';
+        let soapBody = '<tds:SetUser>';
         params.User.forEach((u) => {
             soapBody += '<tds:User>';
             soapBody += `<tt:Username>${u.Username}</tt:Username>`;
             if (u.Password) {
                 soapBody += `<tt:Password>${u.Password}</tt:Password>`;
             }
-            if (u.UserLevel) {
-                soapBody += `<tt:UserLevel>${u.UserLevel}</tt:UserLevel>`;
-            }
+            soapBody += `<tt:UserLevel>${u.UserLevel}<tt:UserLevel>`;
 			soapBody += '</tds:User>';
         });
-        soapBody += '</tds:SetUsers>';
+        soapBody += '</tds:SetUser>';
         const soap = this.createRequestSoap(soapBody);
-        return requestCommand(this.oxaddr, 'SetUsers', soap);
+        return requestCommand(this.oxaddr, 'SetUser', soap);
     }
 
     getRelayOutputs(): Promise<Result> {
@@ -391,7 +389,7 @@ export interface SetNTPParams {
     NTPManual?: IPAddress;
 }
 export interface SetUserParams {
-    User: {Username: string, Password?: string, UserLevel?: 'Administrator' | 'Operator' | 'User' | 'Anonymous' }[];
+    User: {Username: string, Password?: string, UserLevel: 'Administrator' | 'Operator' | 'User' | 'Anonymous' }[];
 }
 
 export interface DeleteUserParams {
@@ -432,9 +430,9 @@ function parseGetSystemDateAndTime(s: any) {
 	const type = s2.DateTimeType || '';
 	let dst = null;
 	if(s2.DaylightSavings) {
-		dst = (s2.DaylightSavings === 'true') ? true : false;
+		dst = s2.DaylightSavings === 'true';
 	}
-	const tz = (s2.TimeZone && s2.TimeZone.TZ) ? s2.TimeZone.TZ : '';
+	const tz = s2.TimeZone?.TZ || '';
 	let date = null;
 	if(s2.UTCDateTime) {
 		const udt = s2.UTCDateTime;

--- a/src/module/service-events.ts
+++ b/src/module/service-events.ts
@@ -14,7 +14,7 @@ export class OnvifServiceEvents extends OnvifServiceBase {
     }
 
     getEventProperties() {
-        const soapBody = '<tds:GetEventProperties/>';
+        const soapBody = '<tev:GetEventProperties/>';
         const soap = this.createRequestSoap(soapBody);
         return requestCommand(this.oxaddr, 'GetEventProperties', soap);
     }

--- a/src/module/service-media.ts
+++ b/src/module/service-media.ts
@@ -43,22 +43,22 @@ export class OnvifServiceMedia extends OnvifServiceBase {
         return requestCommand(this.oxaddr, 'GetVideoEncoderConfiguration', soap);
     }
 
-    getCompatibleVideoEncoderConfigurations(params: ConfigurationTokenParams): Promise<Result> {
+    getCompatibleVideoEncoderConfigurations(params: ProfileTokenParams): Promise<Result> {
         let soapBody = '';
 		soapBody += '<trt:GetCompatibleVideoEncoderConfigurations>';
-		soapBody +=   '<trt:ConfigurationToken>' + params.ConfigurationToken + '</trt:ConfigurationToken>';
+    soapBody += '<trt:ProfileToken>' + params.ProfileToken + '</trt:ProfileToken>';
 		soapBody += '</trt:GetCompatibleVideoEncoderConfigurations>';
         const soap = this.createRequestSoap(soapBody);
-        return requestCommand(this.oxaddr, 'CompatibleVideoEncoderConfigurations', soap);
+        return requestCommand(this.oxaddr, 'GetCompatibleVideoEncoderConfigurations', soap);
     }
 
     getVideoEncoderConfigurationOptions(params: ProfileAndConfigurationTokenOptionalParams): Promise<Result> {
         let soapBody = '';
 		soapBody += '<trt:GetVideoEncoderConfigurationOptions>';
-		if(params.ProfileToken) {
+		if (params.ProfileToken) {
 			soapBody += '<trt:ProfileToken>' + params.ProfileToken + '</trt:ProfileToken>';
 		}
-		if(params.ConfigurationToken) {
+		if (params.ConfigurationToken) {
 			soapBody += '<trt:ConfigurationToken>' + params.ConfigurationToken + '</trt:ConfigurationToken>';
 		}
 		soapBody += '</trt:GetVideoEncoderConfigurationOptions>';
@@ -72,7 +72,7 @@ export class OnvifServiceMedia extends OnvifServiceBase {
 		soapBody +=   '<trt:ConfigurationToken>' + params.ConfigurationToken + '</trt:ConfigurationToken>';
 		soapBody += '</trt:GetGuaranteedNumberOfVideoEncoderInstances>';
         const soap = this.createRequestSoap(soapBody);
-        return requestCommand(this.oxaddr, 'GuaranteedNumberOfVideoEncoderInstances', soap);
+        return requestCommand(this.oxaddr, 'GetGuaranteedNumberOfVideoEncoderInstances', soap);
     }
 
     getProfiles(): Promise<Result> {
@@ -94,7 +94,7 @@ export class OnvifServiceMedia extends OnvifServiceBase {
         let soapBody = '';
 		soapBody += '<trt:CreateProfile>';
         soapBody +=   '<trt:Name>' + params.Name + '</trt:Name>';
-		if(params.Token) {
+		if (params.Token) {
 			soapBody +=   '<trt:Token>' + params.Token + '</trt:Token>';
 		}
 		soapBody += '</trt:CreateProfile>';
@@ -334,7 +334,7 @@ export class OnvifServiceMedia extends OnvifServiceBase {
         return requestCommand(this.oxaddr, 'StopMulticastStreaming', soap);
     }
 
-    GetSnapshotUri(params: ProfileTokenParams): Promise<Result> {
+    getSnapshotUri(params: ProfileTokenParams): Promise<Result> {
         let soapBody = '';
 		soapBody += '<trt:GetSnapshotUri>';
 		soapBody +=   '<trt:ProfileToken>' + params.ProfileToken + '</trt:ProfileToken>';

--- a/src/module/service-ptz.ts
+++ b/src/module/service-ptz.ts
@@ -60,7 +60,9 @@ export class OnvifServicePtz extends OnvifServiceBase {
 		soapBody += '<tptz:ContinuousMove>';
 		soapBody +=   '<tptz:ProfileToken>' + params.ProfileToken + '</tptz:ProfileToken>';
 		soapBody +=   '<tptz:Velocity>';
-		soapBody +=     '<tt:PanTilt x="' + params.Velocity.x + '" y="' + params.Velocity.y + '"></tt:PanTilt>';
+		if(params.Velocity.x && params.Velocity.y) {
+      soapBody +=     '<tt:PanTilt x="' + params.Velocity.x + '" y="' + params.Velocity.y + '"></tt:PanTilt>';
+    }
 		if(params.Velocity.z) {
 			soapBody +=     '<tt:Zoom x="' + params.Velocity.z + '"></tt:Zoom>';
 		}
@@ -85,8 +87,12 @@ export class OnvifServicePtz extends OnvifServiceBase {
 
 		if(params.Speed) {
 			soapBody +=   '<tptz:Speed>';
-			soapBody +=     '<tt:PanTilt x="' + params.Speed.x + '" y="' + params.Speed.y + '" />';
-			soapBody +=     '<tt:Zoom x="' + params.Speed.z + '"/>';
+      if (params.Speed.x && params.Speed.y) {
+        soapBody +=     '<tt:PanTilt x="' + params.Speed.x + '" y="' + params.Speed.y + '" />';
+      }
+      if (params.Speed.z) {
+        soapBody +=     '<tt:Zoom x="' + params.Speed.z + '"/>';
+      }
 			soapBody +=   '</tptz:Speed>';
 		}
 
@@ -107,8 +113,12 @@ export class OnvifServicePtz extends OnvifServiceBase {
 
 		if(params.Speed) {
 			soapBody +=   '<tptz:Speed>';
-			soapBody +=     '<tt:PanTilt x="' + params.Speed.x + '" y="' + params.Speed.y + '" />';
-			soapBody +=     '<tt:Zoom x="' + params.Speed.z + '"/>';
+      if (params.Speed.x && params.Speed.y) {
+        soapBody +=     '<tt:PanTilt x="' + params.Speed.x + '" y="' + params.Speed.y + '" />';
+      }
+      if (params.Speed.z) {
+        soapBody +=     '<tt:Zoom x="' + params.Speed.z + '"/>';
+      }
 			soapBody +=   '</tptz:Speed>';
 		}
 
@@ -184,8 +194,12 @@ export class OnvifServicePtz extends OnvifServiceBase {
 		soapBody +=   '<tptz:PresetToken>' + params.PresetToken + '</tptz:PresetToken>';
 		if(params.Speed) {
 			soapBody +=   '<tptz:Speed>';
-			soapBody +=     '<tt:PanTilt x="' + params.Speed.x + '" y="' + params.Speed.y + '" />';
-			soapBody +=     '<tt:Zoom x="' + params.Speed.z + '"/>';
+      if (params.Speed.x && params.Speed.y) {
+        soapBody +=     '<tt:PanTilt x="' + params.Speed.x + '" y="' + params.Speed.y + '" />';
+      }
+      if (params.Speed.z) {
+        soapBody +=     '<tt:Zoom x="' + params.Speed.z + '"/>';
+      }
 			soapBody +=   '</tptz:Speed>';
 		}
         soapBody += '</tptz:GotoPreset>';
@@ -214,20 +228,20 @@ export interface NodeTokenParams {
 
 export interface ContinuousMoveParams {
     ProfileToken: string;
-    Velocity: {x: number, y: number, z: number};
+    Velocity: {x?: number, y?: number, z?: number}
     Timeout?: number;
 }
 
 export interface AbsoluteMoveParams {
     ProfileToken: string;
-    Position: {x: number, y: number, z: number};
-    Speed: {x: number, y: number, z: number};
+    Position: {x: number, y: number, z: number}
+    Speed?: {x?: number, y?: number, z?: number}
 }
 
 export interface RelativeMoveParams {
     ProfileToken: string;
-    Translation: {x: number, y: number, z: number};
-    Speed: {x: number, y: number, z: number};
+    Translation: {x: number, y: number, z: number}
+    Speed?: {x?: number, y?: number, z?: number}
 }
 
 export interface StopParams {
@@ -248,7 +262,7 @@ export type SetPresetParams = { ProfileToken: string } & (
 export interface GotoPresetParams {
     ProfileToken: string;
     PresetToken: string;
-    Speed?: {x: number, y: number, z: number};
+    Speed?: {x: number, y: number, z: number}
 }
 
 export interface RemovePresetParams {

--- a/src/module/service-ptz.ts
+++ b/src/module/service-ptz.ts
@@ -46,8 +46,11 @@ export class OnvifServicePtz extends OnvifServiceBase {
         return requestCommand(this.oxaddr, 'GetConfigurations', soap);
     }
 
-    getStatus(): Promise<Result> {
-        const soapBody = '<tptz:GetStatus />';
+    getStatus(params: ProfileTokenParams): Promise<Result> {
+        let soapBody = '';
+        soapBody += '<tptz:GetStatus>';
+        soapBody += '<tptz:ProfileToken>' + params.ProfileToken + '</tptz:ProfileToken>';
+        soapBody += '</tptz:GetStatus>';
         const soap = this.createRequestSoap(soapBody);
         return requestCommand(this.oxaddr, 'GetStatus', soap);
     }

--- a/src/module/soap.ts
+++ b/src/module/soap.ts
@@ -147,7 +147,7 @@ function request(oxaddr: UrlWithStringQuery, soap: string): Promise<string> {
             req.setTimeout(HTTP_TIMEOUT);
 
             req.on('timeout', () => {
-                req.abort();
+                req.destroy();
             });
 
             req.on('error', (err) => {

--- a/src/onvif.ts
+++ b/src/onvif.ts
@@ -157,7 +157,7 @@ function sendProbe() {
         });
     });
 
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
 		if (!udp) {
 			reject(new Error('No UDP connection is available. The init() method might not be called yet.'));
 		}
@@ -204,7 +204,7 @@ function stopProbe() {
         discoveryWaitTimer = null;
     }
 
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
         if (udp) {
             udp.close(() => {
                 udp.unref();


### PR DESCRIPTION
This PR fixes a bug that turns into a digest error and also adds some minor changes.
The bug: 
When splitting the keyValue pairs of the digest string, the code doesn't take into account the possibility that the value can have a '=' char in it.
```javascript
    const pair = s.split('=');
    const k = pair[0] as 'algorithm' | 'nonce' | 'Digest realm' | 'qop';
    let v = pair[1];
```
This can be fixed by the following code:
```javascript
    const pair = s.split('=');
    const k = pair[0] as 'algorithm' | 'nonce' | 'Digest realm' | 'qop';
    let v = pair.slice(1).join('=');
```

Other changes contain:
- fix error messages;
- fix tags and variables names;
- and others...